### PR TITLE
Fix name in package.json to match repo name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test-bot",
+  "name": "new-issue-welcome",
   "version": "1.0.0",
   "description": "my test bot",
   "main": "index.js",


### PR DESCRIPTION
The name is only significant when you're adding this repo as a dependency, like in https://github.com/behaviorbot/welcome/pull/1