### PR TITLE
support when config is null

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = robot => {
     if (countIssue.length === 1) {
       try {
         const config = await context.config('config.yml')
-        if (config.newIssueWelcomeComment) {
+        if (config !== null && config.newIssueWelcomeComment) {
           context.github.issues.createComment(context.issue({body: config.newIssueWelcomeComment}))
         }
       } catch (err) {


### PR DESCRIPTION
`context.config('config.yml')` may return null in some cases (for example, https://github.com/probot/probot/blob/master/lib/context.js#L112 ).

This ensures that the `config` is non-null before checking if `newIssueWelcomeComment` is set.