### PR TITLE
Use listForRepo instead of getForRepo

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = app => {
   app.on('issues.opened', async context => {
-    const response = await context.github.issues.getForRepo(context.repo({
+    const response = await context.github.issues.listForRepo(context.repo({
       state: 'all',
       creator: context.payload.issue.user.login
     }))

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 const expect = require('expect')
 const { Application } = require('probot')
+const { GitHubAPI } = require('probot/lib/github')
 const plugin = require('..')
 const successPayload = require('./events/successPayload')
 const successIssueRes = require('./events/successIssueRes')
@@ -14,61 +15,51 @@ describe('new-issue-welcome', () => {
     app = new Application()
     plugin(app)
 
-    github = {
-      repos: {
-        getContents: expect.createSpy().andReturn(Promise.resolve({
-          data: {
-            content: Buffer.from(`newIssueWelcomeComment: >\n  woot woot`).toString('base64')
-          }
-        }))
-      },
-      issues: {
-        getForRepo: expect.createSpy().andReturn(Promise.resolve(
-          successIssueRes
-        )),
-        createComment: expect.createSpy()
-      }
-    }
-
+    github = new GitHubAPI()
     app.auth = () => Promise.resolve(github)
   })
 
+  function makeResponse (msg) {
+    return Promise.resolve({ data: { content: Buffer.from(msg).toString('base64') } })
+  }
+
   describe('new-issue-welcome success', () => {
     it('posts a comment because it is a user\'s first issue opened', async () => {
+      expect.spyOn(github.repos, 'getContents').andReturn(makeResponse(`newIssueWelcomeComment: >\n  woot woot`))
+      expect.spyOn(github.issues, 'listForRepo').andReturn(Promise.resolve(successIssueRes))
+      expect.spyOn(github.issues, 'createComment')
+
       await app.receive(successPayload)
 
-      expect(github.issues.getForRepo).toHaveBeenCalledWith({
+      expect(github.issues.listForRepo).toHaveBeenCalledWith({
         owner: 'hiimbex',
         repo: 'testing-things',
         state: 'all',
         creator: 'hiimbex-test'
       })
-
       expect(github.repos.getContents).toHaveBeenCalledWith({
         owner: 'hiimbex',
         repo: 'testing-things',
         path: '.github/config.yml'
       })
-
       expect(github.issues.createComment).toHaveBeenCalled()
     })
   })
 
   describe('new-issue-welcome failure', () => {
-    beforeEach(() => {
-      github.issues.getForRepo = expect.createSpy().andReturn(Promise.resolve(failIssueRes))
-    })
-
     it('posts a comment because it is a user\'s first issue opened', async () => {
+      expect.spyOn(github.repos, 'getContents').andReturn(makeResponse(`newIssueWelcomeComment: >\n  woot woot`))
+      expect.spyOn(github.issues, 'listForRepo').andReturn(Promise.resolve(failIssueRes))
+      expect.spyOn(github.issues, 'createComment')
+
       await app.receive(failPayload)
 
-      expect(github.issues.getForRepo).toHaveBeenCalledWith({
+      expect(github.issues.listForRepo).toHaveBeenCalledWith({
         owner: 'hiimbex',
         repo: 'testing-things',
         state: 'all',
         creator: 'hiimbex'
       })
-
       expect(github.repos.getContents).toNotHaveBeenCalled()
       expect(github.issues.createComment).toNotHaveBeenCalled()
     })


### PR DESCRIPTION
The GitHub client Probot uses changed `getForRepo` to `listForRepo`. Our tests mocked the GitHub client completely, so we missed that change. Updates the call, and modifies the tests to mock the real client; `expect.spyOn` will fail if it names something that's not already a function.